### PR TITLE
Mainly a reshuffle of dependency keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ resources
 Makefile
 *.o
 *~
+.idea

--- a/META6.json
+++ b/META6.json
@@ -12,19 +12,15 @@
   "resources": [
     "libraries/unix_privileges"
   ],
-  "build-depends": [
-    "LibraryMake",
-	 "Shell::Command"
-  ],
   "author": "github:carbin",
-  "depends": [ ],
+  "depends": [ "LibraryMake",
+	       "Shell::Command" ],
   "tags": [
     "unix",
     "privileges",
     "daemon"
   ],
   "license": "ISC",
-  "test-depends": [ ],
   "provides": {
     "UNIX::Privileges": "lib/UNIX/Privileges.rakumod"
   },


### PR DESCRIPTION
But this may fix #5. The problem is that, although the dependency is found, zef apparently interprets it's not needed before building Unix::Privileges itself, so it fails as shown. In any case, *-depends keys are deprecated, so this will help.
(Also: avoid uploading Comma files)